### PR TITLE
Fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -1,5 +1,8 @@
 name: Run Pyright type check
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/cyraxx/homematicip-rest-mqtt/security/code-scanning/1](https://github.com/cyraxx/homematicip-rest-mqtt/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only performs type checks and does not require write access to any GitHub resources, we can set the permissions to `contents: read`. This ensures the workflow has the minimal access required to function correctly.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
