### PR TITLE
Add support for temperature humidity sensor without display

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ Set point temperature | `homematicip/devices/wall_thermostat/<device_id>/set`
 Current temperature | `homematicip/devices/wall_thermostat/<device_id>/temperature`
 Current humidity | `homematicip/devices/wall_thermostat/<device_id>/humidity`
 
+## Wall mounted thermostat without display
+
+Homematic IP product codes: HMIP-STH
+
+Property | MQTT topic (read) | MQTT topic (write)
+--- | --- | ---
+Low battery state | `homematicip/devices/wall_thermostat/<device_id>/low_battery`
+Current temperature | `homematicip/devices/wall_thermostat/<device_id>/temperature`
+Current humidity | `homematicip/devices/wall_thermostat/<device_id>/humidity`
+Current vapor amount | `homematicip/devices/wall_thermostat/<device_id>/vapor_amount`
+
 ## Window/contact sensor
 
 Homematic IP product codes: HMIP-SWDO, HMIP-SWDO-I, HMIP-SWDM, HMIP-SWDM-B2, HMIP-SCI, HMIP-SRH

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ import aiomqtt
 import homematicip
 from homematicip.async_home import AsyncHome
 from homematicip.device import HeatingThermostat, HeatingThermostatCompact, ShutterContact, ShutterContactMagnetic, \
-    ContactInterface, RotaryHandleSensor, WallMountedThermostatPro, WeatherSensor, HoermannDrivesModule, \
+    ContactInterface, RotaryHandleSensor, WallMountedThermostatPro, TemperatureHumiditySensorWithoutDisplay, WeatherSensor, HoermannDrivesModule, \
     MotionDetectorIndoor, SmokeDetector, AlarmSirenIndoor, LightSensor
 from homematicip.group import HeatingGroup
 from homematicip.base.enums import DoorCommand
@@ -251,6 +251,14 @@ async def process_homematic_payload(payload):
             "set": payload.setPointTemperature,
             "temperature": payload.actualTemperature,
             "humidity": payload.humidity
+        }
+    elif isinstance(payload, TemperatureHumiditySensorWithoutDisplay):
+        topic += f"devices/temperature_humidity_sensor/{payload.id}"
+        data = {
+            "low_battery": payload.lowBat,
+            "temperature": payload.actualTemperature,
+            "humidity": payload.humidity,
+            "vapor_amount": payload.vaporAmount
         }
     elif isinstance(payload, WeatherSensor):
         topic += f"devices/weather/{payload.id}"


### PR DESCRIPTION
Add support for temperature humidity sensor without display.

Product Website (HmIP-STH):
[https://homematic-ip.com/en/product/temperature-and-humidity-sensor-indoor
](https://homematic-ip.com/en/product/temperature-and-humidity-sensor-indoor)
